### PR TITLE
Fix splash screen

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,7 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "tab_size": 2
+}

--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" theme="dark">
   <head>
     <meta charset="UTF-8" />
+    <meta name="color-scheme" content="dark" />
     <link rel="icon" type="image/svg+xml" href="/public/assets/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Anonymous Of The Unheard</title>

--- a/src/AppWrapper.jsx
+++ b/src/AppWrapper.jsx
@@ -3,27 +3,20 @@ import App from "./App";
 import Loader from "./components/loader/Loader";
 
 const AppWrapper = () => {
-  const [showLoader, setShowLoader] = useState(false);
+  const [showLoader, setShowLoader] = useState(true);
 
   useEffect(() => {
-    const alreadyVisited = sessionStorage.getItem("visited");
-
-    const isFirstVisit = !alreadyVisited;
-    const fromExternal =
-      document.referrer === "" ||
-      !document.referrer.includes(window.location.hostname);
-
-    if (isFirstVisit && fromExternal) {
-      sessionStorage.setItem("visited", "true");
-      setShowLoader(true);
-
-      setTimeout(() => {
-        setShowLoader(false);
-      }, 4000);
-    }
+    setTimeout(() => {
+      setShowLoader(false);
+    }, 4000);
   }, []);
 
-  return showLoader ? <Loader /> : <App />;
+  return (
+    <>
+      {showLoader ? <Loader /> : null}
+      <App />;
+    </>
+  );
 };
 
 export default AppWrapper;

--- a/src/components/languageDropdown.css
+++ b/src/components/languageDropdown.css
@@ -103,6 +103,7 @@
 .language-name {
   font-weight: 500;
   font-size: 0.9rem;
+  color: black;
 }
 
 .language-code-small {

--- a/src/components/loader/loader.css
+++ b/src/components/loader/loader.css
@@ -9,6 +9,10 @@
   overflow: hidden;
 }
 
+body:has(.loader-wrapper) {
+  overflow: hidden;
+}
+
 .loader-logo {
   width: 440px;
   height: auto;


### PR DESCRIPTION
- fixed app appearing briefly before the loader appears
- loader is now overlayed on top of the app
- loader is now always displayed on the initial visit
- set color-scheme to dark to reduce flicker on the initial load